### PR TITLE
chore(ai-docs): refresh AI assistant guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,7 +8,7 @@ This repository contains a **Google Chrome extension** (Manifest V3) that enhanc
 
 ### Bootstrap and Build the Repository
 
-- Install required system dependencies: **Node.js 18+** and **Yarn 1.22+**
+- Install required system dependencies: **Node.js 18+** and **Yarn 4+** (Berry). The `packageManager` field in `package.json` pins the exact version; enable [Corepack](https://nodejs.org/api/corepack.html) (`corepack enable`) to use it automatically.
 - Install project dependencies:
   ```bash
   yarn install
@@ -42,7 +42,8 @@ statusinvest-stock-updater/
 ├── package.json                  # Project metadata and build script
 ├── tsconfig.json                 # TypeScript compiler options
 ├── yarn.lock                     # Locked dependency versions
-├── .gitignore                    # Ignores dist/ and node_modules/
+├── LICENSE                       # MIT license
+├── .gitignore                    # Ignores dist/, node_modules/, and Yarn Berry state files
 ├── CHANGELOG.md                  # Release history
 ├── CONTRIBUTING.md               # Contribution guidelines
 └── README.md                     # Project overview and installation instructions
@@ -61,7 +62,7 @@ statusinvest-stock-updater/
 - **Language**: TypeScript (compiled to ES6 / CommonJS via `tsc`)
 - **Platform**: Chrome Extension — Manifest Version 3
 - **External API**: [Alpha Vantage](https://www.alphavantage.co/) — `GLOBAL_QUOTE` endpoint (requires a free API key)
-- **Package manager**: Yarn (`yarn.lock` present; **always use `yarn`, never `npm`**)
+- **Package manager**: Yarn Berry 4.x (`packageManager` field in `package.json`; `yarn.lock` present; **always use `yarn`, never `npm`**)
 - **Dev dependencies**: `typescript ^4.0.0`, `@types/chrome ^0.0.269`
 
 ## CI/CD Pipeline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added `CLAUDE.md` with build commands, conventions, and CI guidance for Claude Code sessions
+
+### Changed
+
+- refreshed `.github/copilot-instructions.md` to reflect Yarn Berry 4.x (was documented as Yarn 1.22+)
+
 ## [0.1.0] - 2026-03-12
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+Chrome Extension (Manifest V3) that adds stock price rows to the "Patrimonio" table on statusinvest.com.br, fetching prices from the Alpha Vantage API.
+
+## Build Commands
+
+```bash
+yarn install    # Install dependencies (uses Yarn Berry 4.x via packageManager field; enable corepack)
+yarn build      # Compile TypeScript to dist/ via tsc
+```
+
+No automated tests exist. Validation is manual: load `dist/` as an unpacked extension in Chrome.
+
+## Conventions
+
+- Always use `yarn`, never `npm`. The `packageManager` field in `package.json` pins Yarn Berry 4.x.
+- TypeScript strict mode is enabled; all code must compile without errors.
+- Never commit a real Alpha Vantage API key — the placeholder `YOUR_ALPHA_VANTAGE_API_KEY` must remain.
+- `dist/` is gitignored; never commit compiled output.
+- Commit conventions follow the [Development Guide](https://github.com/rios0rios0/guide/wiki/Life-Cycle/Git-Flow).
+
+## CI/CD
+
+The workflow (`.github/workflows/default.yaml`) delegates to `rios0rios0/pipelines/.github/workflows/javascript.yaml@main`. No secrets or environment variables needed.


### PR DESCRIPTION
Automated weekly refresh by `ai-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed `CLAUDE.md` and `.github/copilot-instructions.md` against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.