### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -70,7 +70,7 @@ statusinvest-stock-updater/
 The GitHub Actions workflow (`.github/workflows/default.yaml`) delegates to the shared reusable pipeline:
 
 ```yaml
-uses: 'rios0rios0/pipelines/.github/workflows/javascript.yaml@main'
+uses: 'rios0rios0/pipelines/.github/workflows/yarn-library.yaml@main'
 ```
 
 It triggers on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `CLAUDE.md` and `.github/copilot-instructions.md` to reference the `yarn-library.yaml` reusable workflow (was `javascript.yaml`)
+
 ## [0.2.0] - 2026-04-28
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,4 +25,4 @@ No automated tests exist. Validation is manual: load `dist/` as an unpacked exte
 
 ## CI/CD
 
-The workflow (`.github/workflows/default.yaml`) delegates to `rios0rios0/pipelines/.github/workflows/javascript.yaml@main`. No secrets or environment variables needed.
+The workflow (`.github/workflows/default.yaml`) delegates to `rios0rios0/pipelines/.github/workflows/yarn-library.yaml@main`. No secrets or environment variables needed.


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.