### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -36,8 +36,10 @@ statusinvest-stock-updater/
 │   ├── copilot-instructions.md   # This file
 │   └── workflows/
 │       └── default.yaml          # CI/CD pipeline (delegates to rios0rios0/pipelines)
+├── .autobump.yaml                # Auto-bump config (syncs package.json & manifest.json versions)
 ├── background.ts                 # Background service worker: fetches stock prices via Alpha Vantage
 ├── content.ts                    # Content script: detects the table and inserts rows
+├── knip.json                     # Knip config (entry points and ignored dependencies)
 ├── manifest.json                 # Chrome Extension Manifest V3 configuration
 ├── package.json                  # Project metadata and build script
 ├── tsconfig.json                 # TypeScript compiler options
@@ -45,6 +47,7 @@ statusinvest-stock-updater/
 ├── LICENSE                       # MIT license
 ├── .gitignore                    # Ignores dist/, node_modules/, and Yarn Berry state files
 ├── CHANGELOG.md                  # Release history
+├── CLAUDE.md                     # AI assistant guidance (Claude Code)
 ├── CONTRIBUTING.md               # Contribution guidelines
 └── README.md                     # Project overview and installation instructions
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `.github/copilot-instructions.md` to add `.autobump.yaml`, `knip.json`, and `CLAUDE.md` to the repository structure tree
+
 ## [0.2.1] - 2026-05-08
 
 ### Changed


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.